### PR TITLE
allowed extension to be installed on gnome 48 without workarounds

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,6 +2,6 @@
   "uuid": "papershell@lalovene.github.com",
   "name": "PaperShell",
   "description": "Adds a subtle noise texture to reduce eye strain.",
-  "shell-version": ["49"],
+  "shell-version": ["48", "49"],
   "url": "https://github.com/LaloVene/PaperShell"
 }


### PR DESCRIPTION
I tested this version on gnome 48 (debian trixie 13.1) and it works fine on gnome 48 therefore we might as well get official installation methodes... I can also always test if there are breaking changes for gnome 48